### PR TITLE
Making tests work on Cloudant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 target
 project/target
 project/project/target
+/bin/
+.cache
+.classpath
+.project
+.settings/

--- a/src/main/scala/com/ibm/couchdb/CouchDb.scala
+++ b/src/main/scala/com/ibm/couchdb/CouchDb.scala
@@ -53,7 +53,7 @@ object CouchDb {
   }
 
   def apply(host: String, port: Int, https: Boolean, username: String, password: String): CouchDb = {
-    new CouchDb(host, port, https, (username, password).some)
+    new CouchDb(host, port, https, (username, password).some.filter(_._1 != ""))
   }
 
 }

--- a/src/main/scala/com/ibm/couchdb/Model.scala
+++ b/src/main/scala/com/ibm/couchdb/Model.scala
@@ -18,7 +18,10 @@ package com.ibm.couchdb
 
 import sun.misc.BASE64Decoder
 
-case class Config(host: String, port: Int, https: Boolean, credentials: Option[(String, String)])
+class Config private (val host: String, val port: Int, val https: Boolean, val credentials: Option[(String, String)])
+object Config {
+  def apply(host: String, port: Int, https: Boolean, credentials: Option[(String, String)]) = new Config(host, port, https, credentials.filter(_._1 != ""))
+}
 
 case class CouchDoc[T](doc: T,
                        kind: String,

--- a/src/main/scala/com/ibm/couchdb/Res.scala
+++ b/src/main/scala/com/ibm/couchdb/Res.scala
@@ -55,9 +55,9 @@ object Res {
   }
 
   case class ServerInfo(couchdb: String,
-                        uuid: Option[String] = None,
+                        uuid: String = null, //TODO
                         version: String,
-                        vendor: Option[ServerVendor] = None)
+                        vendor: ServerVendor = null) //TODO
 
   case class ServerVendor(version: String, name: String)
 

--- a/src/main/scala/com/ibm/couchdb/api/Databases.scala
+++ b/src/main/scala/com/ibm/couchdb/api/Databases.scala
@@ -16,7 +16,7 @@
 
 package com.ibm.couchdb.api
 
-import com.ibm.couchdb.Res
+import com.ibm.couchdb.{Or, Res}
 import com.ibm.couchdb.core.Client
 import org.http4s.Status
 
@@ -25,7 +25,10 @@ import scalaz.concurrent.Task
 class Databases(client: Client) {
 
   def get(name: String): Task[Res.DbInfo] = {
-    client.get[Res.DbInfo](s"/$name", Status.Ok)
+    client.get[Or[Res.CouchDbInfo,Res.CloudantDbInfo]](s"/$name", Status.Ok).map {
+      case Or(Some(c),_) => c
+      case Or(None, Some(c)) => c
+    }
   }
 
   def getAll: Task[Seq[String]] = {

--- a/src/main/scala/com/ibm/couchdb/core/Client.scala
+++ b/src/main/scala/com/ibm/couchdb/core/Client.scala
@@ -108,7 +108,8 @@ class Client(config: Config) {
   def getBinary(resource: String, expectedStatus: Status): Task[Array[Byte]] = {
     val request = Request(
       method = GET,
-      uri = url(resource))
+      uri = url(resource),
+      headers = baseHeaders)
     req(request, expectedStatus).as[ByteVector].map(_.toArray)
   }
 

--- a/src/test/scala/com/ibm/couchdb/BasicAuthSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/BasicAuthSpec.scala
@@ -26,16 +26,16 @@ class BasicAuthSpec extends CouchDbSpecification {
     SpecConfig.couchDbHost,
     SpecConfig.couchDbPort,
     https = false,
-    SpecConfig.couchDbUsername,
-    SpecConfig.couchDbPassword)
+    "admin",
+    "admin")
 
   val db       = "couchdb-scala-basic-auth-spec"
-  val adminUrl = s"/_config/admins/${ SpecConfig.couchDbUsername }"
+  val adminUrl = s"/_config/admins/admin"
 
   "Basic authentication" >> {
 
     "Only admin can create and delete databases" >> {
-      awaitRight(couch.client.put[String, String](adminUrl, Status.Ok, SpecConfig.couchDbPassword)) mustEqual ""
+      awaitRight(couch.client.put[String, String](adminUrl, Status.Ok, "admin")) mustEqual ""
       awaitError(couch.dbs.create(db), "unauthorized")
       await(couchAdmin.dbs.delete(db))
       awaitOk(couchAdmin.dbs.create(db))

--- a/src/test/scala/com/ibm/couchdb/CouchDbSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/CouchDbSpec.scala
@@ -23,7 +23,7 @@ import org.specs2.matcher.MatchResult
 
 class CouchDbSpec extends CouchDbSpecification {
 
-  val couch = CouchDb(SpecConfig.couchDbHost, SpecConfig.couchDbPort)
+  val couch = CouchDb(SpecConfig.couchDbHost, SpecConfig.couchDbPort, https = false, SpecConfig.couchDbUsername, SpecConfig.couchDbPassword)
 
   val db1 = "couchdb-scala-couchdb-spec1"
   val db2 = "couchdb-scala-couchdb-spec2"
@@ -40,7 +40,7 @@ class CouchDbSpec extends CouchDbSpecification {
         await(couch.dbs.delete(dbName))
         val error = awaitLeft(couch.dbs.delete(dbName))
         error.error mustEqual "not_found"
-        error.reason mustEqual "missing"
+        Seq("Database does not exist.", "missing") must contain(error.reason)
         error.status mustEqual Status.NotFound
         error.request must contain("DELETE")
         error.request must contain(dbName)

--- a/src/test/scala/com/ibm/couchdb/api/DesignSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DesignSpec.scala
@@ -38,7 +38,7 @@ class DesignSpec extends CouchDbSpecification {
       clear()
       awaitDocOk(design.create(fixDesign))
       val info = awaitRight(design.info(fixDesign.name))
-      info.name mustEqual fixDesign.name
+      Seq(fixDesign.name, "_design/" + fixDesign.name) must contain(info.name)
       info.view_index.language mustEqual "javascript"
       info.view_index.disk_size must beGreaterThan(0)
     }

--- a/src/test/scala/com/ibm/couchdb/api/QueryViewSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/QueryViewSpec.scala
@@ -68,7 +68,6 @@ class QueryViewSpec extends CouchDbSpecification {
 
     "Query a view and select by key" >> {
       val docs1 = awaitRight(namesView.key("Alice").query)
-      docs1.offset mustEqual 0
       docs1.total_rows mustEqual 3
       docs1.rows must haveLength(1)
       docs1.rows(0).key mustEqual "Alice"
@@ -92,7 +91,6 @@ class QueryViewSpec extends CouchDbSpecification {
 
     "Query a view with a set of keys" >> {
       val docs = awaitRight(namesView.query(Seq(fixAlice.name, fixBob.name)))
-      docs.offset mustEqual 0
       docs.total_rows mustEqual 3
       docs.rows must haveLength(2)
       docs.rows.map(_.key) mustEqual Seq(fixAlice.name, fixBob.name)
@@ -101,7 +99,6 @@ class QueryViewSpec extends CouchDbSpecification {
 
     "Query a view with a set of keys and include documents" >> {
       val docs = awaitRight(namesView.queryIncludeDocs[FixPerson](Seq(fixAlice.name, fixBob.name)))
-      docs.offset mustEqual 0
       docs.total_rows mustEqual 3
       docs.rows must haveLength(2)
       docs.rows.map(_.key) mustEqual Seq(fixAlice.name, fixBob.name)

--- a/src/test/scala/com/ibm/couchdb/api/ServerSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/ServerSpec.scala
@@ -28,7 +28,7 @@ class ServerSpec extends CouchDbSpecification {
     "Get info about the DB instance" >> {
       val info = awaitRight(server.info)
       info.couchdb mustEqual "Welcome"
-      info.uuid must beOptUuid
+      Option(info.uuid) must beOptUuid
       info.version.length must beGreaterThanOrEqualTo(3)
     }
 

--- a/src/test/scala/com/ibm/couchdb/api/ServerSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/ServerSpec.scala
@@ -28,7 +28,7 @@ class ServerSpec extends CouchDbSpecification {
     "Get info about the DB instance" >> {
       val info = awaitRight(server.info)
       info.couchdb mustEqual "Welcome"
-      info.uuid must beUuid
+      info.uuid must beOptUuid
       info.version.length must beGreaterThanOrEqualTo(3)
     }
 

--- a/src/test/scala/com/ibm/couchdb/spec/CouchDbSpecification.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/CouchDbSpecification.scala
@@ -37,7 +37,7 @@ trait CouchDbSpecification extends Specification with
                                    UpickleImplicits {
   sequential
 
-  val client = new Client(Config(SpecConfig.couchDbHost, SpecConfig.couchDbPort, https = false, None))
+  val client = new Client(Config(SpecConfig.couchDbHost, SpecConfig.couchDbPort, https = false, Some(SpecConfig.couchDbUsername -> SpecConfig.couchDbPassword)))
 
   def await[T](future: Task[T]): Throwable \/ T = future.attemptRun
 
@@ -75,6 +75,8 @@ trait CouchDbSpecification extends Specification with
 
   def beUuid: Matcher[String] = haveLength(32)
 
+  def beOptUuid = beNone or beSome[String](beUuid)
+  
   def beRev: Matcher[String] = (_: String).length must beGreaterThan(32)
 
   def checkDocOk(doc: Res.DocOk): MatchResult[Any] = {

--- a/src/test/scala/com/ibm/couchdb/spec/SpecConfig.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/SpecConfig.scala
@@ -21,16 +21,9 @@ object SpecConfig {
   val couchDbHost      = System.getProperty("couchDbHost", "127.0.0.1")
   val couchDbPort      = System.getProperty("couchDbPort", "5984").toInt
   val couchDbHttpsPort = System.getProperty("couchDbHttpsPort", "6984").toInt
-  val couchDbUsername  = System.getProperty("couchDbUsername", "admin")
-  val couchDbPassword  = System.getProperty("couchDbPassword", "admin")
-  
-  val couchDbAdminHost      = System.getProperty("couchDbAdminHost", "127.0.0.1")
-  val couchDbAdminPort      = System.getProperty("couchDbAdminPort", "5984").toInt
-  val couchDbAdminHttpsPort = System.getProperty("couchDbAdminHttpsPort", "6984").toInt
-  val couchDbAdminUsername  = System.getProperty("couchDbAdminUsername", "admin")
-  val couchDbAdminPassword  = System.getProperty("couchDbAdminPassword", "admin")
+  val couchDbUsername  = System.getProperty("couchDbUsername", "")
+  val couchDbPassword  = System.getProperty("couchDbPassword", "")
    
-  
   private val log = org.log4s.getLogger
 
   log.info("----------------------")

--- a/src/test/scala/com/ibm/couchdb/spec/SpecConfig.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/SpecConfig.scala
@@ -23,12 +23,18 @@ object SpecConfig {
   val couchDbHttpsPort = System.getProperty("couchDbHttpsPort", "6984").toInt
   val couchDbUsername  = System.getProperty("couchDbUsername", "admin")
   val couchDbPassword  = System.getProperty("couchDbPassword", "admin")
-
+  
+  val couchDbAdminHost      = System.getProperty("couchDbAdminHost", "127.0.0.1")
+  val couchDbAdminPort      = System.getProperty("couchDbAdminPort", "5984").toInt
+  val couchDbAdminHttpsPort = System.getProperty("couchDbAdminHttpsPort", "6984").toInt
+  val couchDbAdminUsername  = System.getProperty("couchDbAdminUsername", "admin")
+  val couchDbAdminPassword  = System.getProperty("couchDbAdminPassword", "admin")
+   
+  
   private val log = org.log4s.getLogger
 
   log.info("----------------------")
   log.info(s"couchDbHost: $couchDbHost")
   log.info(s"couchDbPort: $couchDbPort")
   log.info("----------------------")
-
 }


### PR DESCRIPTION
To start off, I made the tests pass on Cloudant. I had to modify the way the tests and the library handle authentication a bit (always using a username and password if one is provided through system properties) but other than that, functionality should be unchanged. 

There are a few cases where the JSON format returned by Cloudant is different and I've accounted for those as well.

The "offset" value in views is not as predictable as it might seem and need not be 0 even if skip is not specified. Where the offset value can't be predicted from the test setup, I've removed assertions.

The only Spec that still doesn't pass is BasicAuthSpec. I don't think it can be made to work on Cloudant as it is, but it's still useful to have for CouchDB.
