### PR TITLE
Fixed issue with retrieving unicode values (fixes #4) by adding a def…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 libraryDependencies ++= Seq(
   "org.scalaz"                  %% "scalaz-core"                 % "7.1.0",
   "org.scalaz"                  %% "scalaz-effect"               % "7.1.0",
-  "org.http4s"                  %% "http4s-core"                 % "0.8.1",
-  "org.http4s"                  %% "http4s-client"               % "0.8.1",
-  "org.http4s"                  %% "http4s-blazeclient"          % "0.8.1",
+  "org.http4s"                  %% "http4s-core"                 % "0.8.2",
+  "org.http4s"                  %% "http4s-client"               % "0.8.2",
+  "org.http4s"                  %% "http4s-blazeclient"          % "0.8.2",
   "com.lihaoyi"                 %% "upickle"                     % "0.2.6",
   "com.github.julien-truffaut"  %% "monocle-core"                % "1.0.1",
   "com.github.julien-truffaut"  %% "monocle-macro"               % "1.0.1",

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ resolvers += "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
 libraryDependencies ++= Seq(
   "org.scalaz"                  %% "scalaz-core"                 % "7.1.0",
   "org.scalaz"                  %% "scalaz-effect"               % "7.1.0",
-  "org.http4s"                  %% "http4s-core"                 % "0.6.1",
-  "org.http4s"                  %% "http4s-client"               % "0.6.1",
-  "org.http4s"                  %% "http4s-blazeclient"          % "0.6.1",
+  "org.http4s"                  %% "http4s-core"                 % "0.8.1",
+  "org.http4s"                  %% "http4s-client"               % "0.8.1",
+  "org.http4s"                  %% "http4s-blazeclient"          % "0.8.1",
   "com.lihaoyi"                 %% "upickle"                     % "0.2.6",
   "com.github.julien-truffaut"  %% "monocle-core"                % "1.0.1",
   "com.github.julien-truffaut"  %% "monocle-macro"               % "1.0.1",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
-addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.11")
+addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.13")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 

--- a/src/main/scala/com/ibm/couchdb/core/Client.scala
+++ b/src/main/scala/com/ibm/couchdb/core/Client.scala
@@ -37,10 +37,11 @@ class Client(config: Config) {
 
   val client = PooledHttp1Client()
 
-  val baseHeaders = config.credentials match {
+  val baseHeaders           = config.credentials match {
     case Some(x) => Headers(Authorization(BasicCredentials(x._1, x._2)))
     case None => Headers()
   }
+  val baseHeadersWithAccept = baseHeaders.put(Header("Accept", "application/json; charset=utf-8"))
 
   val baseUri = Uri(
     scheme = CaseInsensitiveString(if (config.https) "https" else "http").some,
@@ -91,7 +92,7 @@ class Client(config: Config) {
     val request = Request(
       method = GET,
       uri = url(resource, params),
-      headers = baseHeaders.put(Header("Accept", "application/json")))
+      headers = baseHeadersWithAccept)
     req(request, expectedStatus).as[String]
   }
 
@@ -101,7 +102,7 @@ class Client(config: Config) {
     val request = Request(
       method = GET,
       uri = url(resource, params),
-      headers = baseHeaders.put(Header("Accept", "application/json")))
+      headers = baseHeadersWithAccept)
     reqAndRead[T](request, expectedStatus)
   }
 
@@ -116,7 +117,6 @@ class Client(config: Config) {
                         expectedStatus: Status,
                         entity: EntityEncoder.Entity,
                         contentType: String): Task[T] = {
-    val baseHeadersWithAccept = baseHeaders.put(Header("Accept", "application/json"))
     val headers =
       if (!contentType.isEmpty) baseHeadersWithAccept.put(Header("Content-Type", contentType))
       else baseHeadersWithAccept
@@ -153,8 +153,7 @@ class Client(config: Config) {
       val request = Request(
         method = POST,
         uri = url(resource, params),
-        headers = baseHeaders.put(
-          Header("Accept", "application/json"),
+        headers = baseHeadersWithAccept.put(
           Header("Content-Type", "application/json")),
         body = entity.body)
       reqAndRead[T](request, expectedStatus)
@@ -165,7 +164,7 @@ class Client(config: Config) {
     val request = Request(
       method = DELETE,
       uri = url(resource),
-      headers = baseHeaders.put(Header("Accept", "application/json")))
+      headers = baseHeadersWithAccept)
     reqAndRead[T](request, expectedStatus)
   }
 

--- a/src/main/scala/com/ibm/couchdb/core/Client.scala
+++ b/src/main/scala/com/ibm/couchdb/core/Client.scala
@@ -37,7 +37,7 @@ class Client(config: Config) {
 
   val client = PooledHttp1Client()
 
-  val baseHeaders           = config.credentials match {
+  val baseHeaders = config.credentials match {
     case Some(x) => Headers(Authorization(BasicCredentials(x._1, x._2)))
     case None => Headers()
   }
@@ -62,7 +62,7 @@ class Client(config: Config) {
       if (response.status == expectedStatus) {
         Task.now(response)
       } else {
-        log.warn(s"Unexpected response status ${ response.status }, expected $expectedStatus")
+        log.warn(s"Unexpected response status ${response.status}, expected $expectedStatus")
         for {
           responseBody <- response.as[String]
           requestBody <- EntityDecoder.decodeString(request)

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -125,7 +125,7 @@ class DocumentsSpec extends CouchDbSpecification {
       awaitRight(documents.get[FixPerson](created1.id)).doc mustEqual fixHaile
 
       val created2 = awaitRight(documents.createMany[FixPerson](Seq(fixHaile, fixMagritte)))
-      val docs = awaitRight(documents.getMany.queryIncludeDocs[FixPerson](Seq(created2.head.id, created2(1).id)))
+      val docs = awaitRight(documents.getMany.queryIncludeDocs[FixPerson](created2.map(_.id)))
       docs.getDocs.map(_.doc) mustEqual Seq(fixHaile, fixMagritte)
     }
 
@@ -173,8 +173,8 @@ class DocumentsSpec extends CouchDbSpecification {
       val created = awaitRight(documents.create(fixAlice))
       val aliceRes = awaitRight(documents.get[FixPerson](created.id))
       awaitDocOk(documents.attach(aliceRes, fixAttachmentName, fixAttachmentData))
-      val url = s"http://${ SpecConfig.couchDbHost }:${ SpecConfig.couchDbPort }" +
-        s"/${ db }/${ aliceRes._id }/${ fixAttachmentName }"
+      val url = s"http://${SpecConfig.couchDbHost}:${SpecConfig.couchDbPort}" +
+        s"/${db}/${aliceRes._id}/${fixAttachmentName}"
       awaitRight(documents.getAttachmentUrl(aliceRes, fixAttachmentName)) mustEqual url
       awaitRight(documents.getAttachment(aliceRes, fixAttachmentName)) mustEqual fixAttachmentData
     }

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -119,6 +119,16 @@ class DocumentsSpec extends CouchDbSpecification {
       docs.getDocsData mustEqual Seq(fixAlice, fixCarl)
     }
 
+    "Get a document containing unicode values" >> {
+      clear()
+      val created1 = awaitRight(documents.create[FixPerson](fixHaile))
+      awaitRight(documents.get[FixPerson](created1.id)).doc mustEqual fixHaile
+
+      val created2 = awaitRight(documents.createMany[FixPerson](Seq(fixHaile, fixMagritte)))
+      val docs = awaitRight(documents.getMany.queryIncludeDocs[FixPerson](Seq(created2.head.id, created2(1).id)))
+      docs.getDocs.map(_.doc) mustEqual Seq(fixHaile, fixMagritte)
+    }
+
     "Update a document" >> {
       val created = awaitRight(documents.create(fixAlice))
       val aliceRes = awaitRight(documents.get[FixPerson](created.id))
@@ -216,6 +226,6 @@ class DocumentsSpec extends CouchDbSpecification {
       awaitError(documents.getAttachment(aliceRes, fixAttachmentName), "not_found")
     }
 
-  }
 
+  }
 }

--- a/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
@@ -32,9 +32,11 @@ trait Fixtures {
   val _docPersonName = _couchDoc composeLens _personName
   val _docPersonAge  = _couchDoc composeLens _personAge
 
-  val fixAlice = FixPerson("Alice", 25)
-  val fixBob   = FixPerson("Bob", 30)
-  val fixCarl  = FixPerson("Carl", 20)
+  val fixAlice  = FixPerson("Alice", 25)
+  val fixBob    = FixPerson("Bob", 30)
+  val fixCarl   = FixPerson("Carl", 20)
+  val fixHaile = FixPerson("\u1283\u12ED\u120C \u1308\u1265\u1228\u1225\u120B\u1234", 42)
+  val fixMagritte= FixPerson("Ren\u00E9 Magritte", 68)
 
   object FixViews {
     val names    = "names"

--- a/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
@@ -32,11 +32,11 @@ trait Fixtures {
   val _docPersonName = _couchDoc composeLens _personName
   val _docPersonAge  = _couchDoc composeLens _personAge
 
-  val fixAlice  = FixPerson("Alice", 25)
-  val fixBob    = FixPerson("Bob", 30)
-  val fixCarl   = FixPerson("Carl", 20)
-  val fixHaile = FixPerson("\u1283\u12ED\u120C \u1308\u1265\u1228\u1225\u120B\u1234", 42)
-  val fixMagritte= FixPerson("Ren\u00E9 Magritte", 68)
+  val fixAlice    = FixPerson("Alice", 25)
+  val fixBob      = FixPerson("Bob", 30)
+  val fixCarl     = FixPerson("Carl", 20)
+  val fixHaile    = FixPerson("\u1283\u12ED\u120C \u1308\u1265\u1228\u1225\u120B\u1234", 42)
+  val fixMagritte = FixPerson("Ren\u00E9 Magritte", 68)
 
   object FixViews {
     val names    = "names"


### PR DESCRIPTION
Fixed issue with retrieving unicode values (fixes #4) by adding a default charset (utf-8) to the headers of the client's requests. 

Using http4s' modified EntityDecoder.decodeString with a defaultCharset as suggested by @bryce-anderson might have been a good approach to this but seems to have a couple of problems. From what I can gather, without an Accept charset header in the request, the response from Couch would not contain a charset in the Content-Type header. The Content-Type attribute inside a client Response object in Http4s contains an optional charset attribute which defaults to Charset.`ISO-8859-1` if not defined. Hence, an attempt to decode the response using EntityDecoder.decodeString(response, defaultCharset=Charset.`UTF-8`) for instance, would ignore the defaultCharset because response.charset is always defined by default. @bryce-anderson, I hope I did not miss something here 

@beloglazov , what do you think about making the default charset a configurable property for the client? 
