### PR TITLE
Added a test for updating a doc with multiple attachments

### DIFF
--- a/src/main/scala/com/ibm/couchdb/Model.scala
+++ b/src/main/scala/com/ibm/couchdb/Model.scala
@@ -73,6 +73,14 @@ case class CouchAttachment(content_type: String,
   def toBytes: Array[Byte] = Base64.getDecoder.decode(data)
 }
 
+case object CouchAttachment {
+  def fromBytes(data: Array[Byte], content_type: String = ""): CouchAttachment = {
+    CouchAttachment(
+      content_type = content_type,
+      data = Base64.getEncoder.encodeToString(data))
+  }
+}
+
 case class CouchView(map: String, reduce: String = "")
 
 case class CouchDesign(name: String,

--- a/src/main/scala/com/ibm/couchdb/Model.scala
+++ b/src/main/scala/com/ibm/couchdb/Model.scala
@@ -18,6 +18,8 @@ package com.ibm.couchdb
 
 import java.util.Base64
 
+import org.http4s.headers.`Content-Type`
+
 import scalaz.\/
 
 case class Config(host: String, port: Int, https: Boolean, credentials: Option[(String, String)])
@@ -78,6 +80,12 @@ case object CouchAttachment {
     CouchAttachment(
       content_type = content_type,
       data = Base64.getEncoder.encodeToString(data))
+  }
+
+  def fromBytes(data: Array[Byte], content_type: `Content-Type`): CouchAttachment = {
+    CouchAttachment(
+                     content_type = content_type.toString,
+                     data = Base64.getEncoder.encodeToString(data))
   }
 }
 

--- a/src/main/scala/com/ibm/couchdb/Req.scala
+++ b/src/main/scala/com/ibm/couchdb/Req.scala
@@ -18,8 +18,6 @@ package com.ibm.couchdb
 
 object Req {
 
-  case class Attachment(data: Array[Byte], content_type: String = "")
-
   case class Docs[D](docs: Seq[CouchDoc[D]])
 
   case class DocKeys[K](keys: Seq[K])

--- a/src/main/scala/com/ibm/couchdb/api/Documents.scala
+++ b/src/main/scala/com/ibm/couchdb/api/Documents.scala
@@ -35,25 +35,18 @@ class Documents(client: Client, db: String, typeMapping: TypeMapping) {
     server.mkUuid flatMap (create(obj, _))
   }
 
-  def create[D: W](obj: D, attachments: Map[String, Req.Attachment]): Task[Res.DocOk] = {
+  def create[D: W](obj: D, attachments: Map[String, CouchAttachment]): Task[Res.DocOk] = {
     server.mkUuid flatMap (create(obj, _, attachments))
   }
 
-  def create[D: W](obj: D, id: String, attachments: Map[String, Req.Attachment] = Map.empty)
+  def create[D: W](obj: D, id: String, attachments: Map[String, CouchAttachment] = Map.empty)
   : Task[Res.DocOk] = {
     typeMapping.forType(obj.getClass) match {
       case Some(t) =>
-        val _attachments =
-          if (attachments.nonEmpty)
-            attachments.mapValues(x =>
-              CouchAttachment(
-                data = Base64.getEncoder.encodeToString(x.data),
-                content_type = x.content_type))
-          else Map.empty[String, CouchAttachment]
         client.put[CouchDoc[D], Res.DocOk](
           s"/$db/$id",
           Status.Created,
-          CouchDoc[D](obj, t, _attachments = _attachments))
+          CouchDoc[D](obj, t, _attachments = attachments))
       case None =>
         val cl = obj.getClass.getCanonicalName
         Res.Error(

--- a/src/main/scala/com/ibm/couchdb/api/Documents.scala
+++ b/src/main/scala/com/ibm/couchdb/api/Documents.scala
@@ -17,10 +17,9 @@
 package com.ibm.couchdb.api
 
 import java.nio.file.{Files, Paths}
-import java.util.Base64
 
 import com.ibm.couchdb._
-import com.ibm.couchdb.api.builders.{GetManyDocumentsQueryBuilder, GetDocumentQueryBuilder}
+import com.ibm.couchdb.api.builders.{GetDocumentQueryBuilder, GetManyDocumentsQueryBuilder}
 import com.ibm.couchdb.core.Client
 import org.http4s.Status
 import upickle.default.Aliases.{R, W}

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -240,7 +240,7 @@ class DocumentsSpec extends CouchDbSpecification {
       attachment.digest must not be empty
       attachment.toBytes mustEqual fixAttachmentData
       val attachment2 = doc._attachments(fixAttachment2Name)
-      attachment2.content_type mustEqual fixAttachment2ContentType
+      attachment2.content_type mustEqual fixAttachment2ContentType.toString
       attachment2.length mustEqual -1
       attachment2.stub mustEqual false
       attachment2.digest must not be empty
@@ -342,7 +342,7 @@ class DocumentsSpec extends CouchDbSpecification {
       attachment.digest must not be empty
       attachment.toBytes mustEqual fixAttachmentData
       val attachment2 = doc._attachments(fixAttachment2Name)
-      attachment2.content_type mustEqual fixAttachment2ContentType
+      attachment2.content_type mustEqual fixAttachment2ContentType.toString
       attachment2.length mustEqual -1
       attachment2.stub mustEqual false
       attachment2.digest must not be empty

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -325,9 +325,11 @@ class DocumentsSpec extends CouchDbSpecification {
     }
 
     "Create and get a document with attachments" >> {
-      val attachments = Map[String, Req.Attachment](
-        fixAttachmentName -> Req.Attachment(fixAttachmentData, fixAttachmentContentType),
-        fixAttachment2Name -> Req.Attachment(fixAttachment2Data, fixAttachment2ContentType))
+      val attachments = Map[String, CouchAttachment](
+        fixAttachmentName -> CouchAttachment.fromBytes(
+          fixAttachmentData, fixAttachmentContentType),
+        fixAttachment2Name -> CouchAttachment.fromBytes(
+          fixAttachment2Data, fixAttachment2ContentType))
       val created = awaitRight(documents.create(fixAlice, attachments))
       val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
       doc._id mustEqual created.id

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -218,35 +218,6 @@ class DocumentsSpec extends CouchDbSpecification {
       aliceRes2.doc.age mustEqual fixAlice.age + 1
     }
 
-    "Update a document with attachments" >> {
-      val created = awaitRight(documents.create(fixAlice))
-      val aliceRes = awaitRight(documents.get[FixPerson](created.id))
-      val aliceWithAttachments = aliceRes.copy(
-        _attachments = Map(
-          fixAttachmentName -> CouchAttachment.fromBytes(
-            fixAttachmentData, fixAttachmentContentType),
-          fixAttachment2Name -> CouchAttachment.fromBytes(
-            fixAttachment2Data, fixAttachment2ContentType)))
-      val docOk = awaitRight(documents.update(aliceWithAttachments))
-      checkDocOk(docOk, aliceRes._id)
-      val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
-      doc._id mustEqual created.id
-      doc._attachments must haveLength(2)
-      doc._attachments must haveKeys(fixAttachmentName, fixAttachment2Name)
-      val attachment = doc._attachments(fixAttachmentName)
-      attachment.content_type mustEqual fixAttachmentContentType
-      attachment.length mustEqual -1
-      attachment.stub mustEqual false
-      attachment.digest must not be empty
-      attachment.toBytes mustEqual fixAttachmentData
-      val attachment2 = doc._attachments(fixAttachment2Name)
-      attachment2.content_type mustEqual fixAttachment2ContentType.toString
-      attachment2.length mustEqual -1
-      attachment2.stub mustEqual false
-      attachment2.digest must not be empty
-      attachment2.toBytes mustEqual fixAttachment2Data
-    }
-
     "Fail to update a document without ID" >> {
       val created = awaitRight(documents.create(fixAlice))
       val aliceRes = awaitRight(documents.get[FixPerson](created.id))
@@ -331,6 +302,35 @@ class DocumentsSpec extends CouchDbSpecification {
         fixAttachment2Name -> CouchAttachment.fromBytes(
           fixAttachment2Data, fixAttachment2ContentType))
       val created = awaitRight(documents.create(fixAlice, attachments))
+      val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
+      doc._id mustEqual created.id
+      doc._attachments must haveLength(2)
+      doc._attachments must haveKeys(fixAttachmentName, fixAttachment2Name)
+      val attachment = doc._attachments(fixAttachmentName)
+      attachment.content_type mustEqual fixAttachmentContentType
+      attachment.length mustEqual -1
+      attachment.stub mustEqual false
+      attachment.digest must not be empty
+      attachment.toBytes mustEqual fixAttachmentData
+      val attachment2 = doc._attachments(fixAttachment2Name)
+      attachment2.content_type mustEqual fixAttachment2ContentType.toString
+      attachment2.length mustEqual -1
+      attachment2.stub mustEqual false
+      attachment2.digest must not be empty
+      attachment2.toBytes mustEqual fixAttachment2Data
+    }
+
+    "Update a document with attachments" >> {
+      val created = awaitRight(documents.create(fixAlice))
+      val aliceRes = awaitRight(documents.get[FixPerson](created.id))
+      val aliceWithAttachments = aliceRes.copy(
+        _attachments = Map(
+          fixAttachmentName -> CouchAttachment.fromBytes(
+            fixAttachmentData, fixAttachmentContentType),
+          fixAttachment2Name -> CouchAttachment.fromBytes(
+            fixAttachment2Data, fixAttachment2ContentType)))
+      val docOk = awaitRight(documents.update(aliceWithAttachments))
+      checkDocOk(docOk, aliceRes._id)
       val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
       doc._id mustEqual created.id
       doc._attachments must haveLength(2)

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -16,7 +16,7 @@
 
 package com.ibm.couchdb.api
 
-import com.ibm.couchdb.{CouchDoc, Req}
+import com.ibm.couchdb.{CouchAttachment, CouchDoc, Req}
 import com.ibm.couchdb.spec.{CouchDbSpecification, SpecConfig}
 import monocle.syntax._
 import org.http4s.Status
@@ -216,6 +216,35 @@ class DocumentsSpec extends CouchDbSpecification {
       aliceRes2._rev mustEqual docOk.rev
       aliceRes2.doc.name mustEqual fixAlice.name
       aliceRes2.doc.age mustEqual fixAlice.age + 1
+    }
+
+    "Update a document with attachments" >> {
+      val created = awaitRight(documents.create(fixAlice))
+      val aliceRes = awaitRight(documents.get[FixPerson](created.id))
+      val aliceWithAttachments = aliceRes.copy(
+        _attachments = Map(
+          fixAttachmentName -> CouchAttachment.fromBytes(
+            fixAttachmentData, fixAttachmentContentType),
+          fixAttachment2Name -> CouchAttachment.fromBytes(
+            fixAttachment2Data, fixAttachment2ContentType)))
+      val docOk = awaitRight(documents.update(aliceWithAttachments))
+      checkDocOk(docOk, aliceRes._id)
+      val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
+      doc._id mustEqual created.id
+      doc._attachments must haveLength(2)
+      doc._attachments must haveKeys(fixAttachmentName, fixAttachment2Name)
+      val attachment = doc._attachments(fixAttachmentName)
+      attachment.content_type mustEqual fixAttachmentContentType
+      attachment.length mustEqual -1
+      attachment.stub mustEqual false
+      attachment.digest must not be empty
+      attachment.toBytes mustEqual fixAttachmentData
+      val attachment2 = doc._attachments(fixAttachment2Name)
+      attachment2.content_type mustEqual fixAttachment2ContentType
+      attachment2.length mustEqual -1
+      attachment2.stub mustEqual false
+      attachment2.digest must not be empty
+      attachment2.toBytes mustEqual fixAttachment2Data
     }
 
     "Fail to update a document without ID" >> {

--- a/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
+++ b/src/test/scala/com/ibm/couchdb/api/DocumentsSpec.scala
@@ -16,8 +16,8 @@
 
 package com.ibm.couchdb.api
 
-import com.ibm.couchdb.{CouchAttachment, CouchDoc, Req}
 import com.ibm.couchdb.spec.{CouchDbSpecification, SpecConfig}
+import com.ibm.couchdb.{CouchAttachment, CouchDoc}
 import monocle.syntax._
 import org.http4s.Status
 
@@ -333,8 +333,8 @@ class DocumentsSpec extends CouchDbSpecification {
       checkDocOk(docOk, aliceRes._id)
       val doc = awaitRight(documents.get.attachments().query[FixPerson](created.id))
       doc._id mustEqual created.id
-      doc._attachments must haveLength(2)
-      doc._attachments must haveKeys(fixAttachmentName, fixAttachment2Name)
+      doc._attachments.keys must containTheSameElementsAs(Seq(fixAttachmentName,
+                                                              fixAttachment2Name))
       val attachment = doc._attachments(fixAttachmentName)
       attachment.content_type mustEqual fixAttachmentContentType
       attachment.length mustEqual -1

--- a/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
+++ b/src/test/scala/com/ibm/couchdb/spec/Fixtures.scala
@@ -19,6 +19,8 @@ package com.ibm.couchdb.spec
 import com.ibm.couchdb.Lenses._
 import com.ibm.couchdb._
 import monocle.macros.GenLens
+import org.http4s.MediaType
+import org.http4s.headers.`Content-Type`
 
 trait Fixtures {
 
@@ -148,6 +150,6 @@ trait Fixtures {
   val fixAttachmentContentType   = "image/jpg"
   val fixAttachment2Name         = "attachment2"
   val fixAttachment2Data         = Array[Byte](-1, 0, 1, 2, 3, 4, 5)
-  val fixAttachment2ContentType  = "image/png"
+  val fixAttachment2ContentType  = `Content-Type`(MediaType.`image/png`)
 
 }


### PR DESCRIPTION
Also added CouchAttachment.fromBytes and replaced Req.Attachment with CouchAttachment, which simplified the code. Fixes #22.
