### PR TITLE
[WIP] Scala 2.12 (help needed)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ version := "0.8.0-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
+crossScalaVersions := Seq("2.12.4")
+
 description := "A purely functional Scala client for CouchDB"
 
 homepage := Some(url("https://github.com/beloglazov/couchdb-scala"))
@@ -20,21 +22,27 @@ licenses := Seq("The Apache Software License, Version 2.0"
   -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 libraryDependencies ++= Seq(
-  "org.scalaz"                  %% "scalaz-core"                 % "7.2.6",
-  "org.scalaz"                  %% "scalaz-effect"               % "7.2.6",
-  "org.http4s"                  %% "http4s-core"                 % "0.14.6a",
-  "org.http4s"                  %% "http4s-client"               % "0.14.6a",
-  "org.http4s"                  %% "http4s-blaze-client"         % "0.14.6a",
-  "com.lihaoyi"                 %% "upickle"                     % "0.4.1",
-  "com.github.julien-truffaut"  %% "monocle-core"                % "1.2.2",
-  "com.github.julien-truffaut"  %% "monocle-macro"               % "1.2.2",
-  "org.log4s"                   %% "log4s"                       % "1.3.0",
+  "org.scalaz"                  %% "scalaz-core"                 % "7.2.9",
+  "org.scalaz"                  %% "scalaz-effect"               % "7.2.9",
+  "org.http4s"                  %% "http4s-core"                 % "0.15.0",
+  "org.http4s"                  %% "http4s-client"               % "0.15.0",
+  "org.http4s"                  %% "http4s-blaze-client"         % "0.15.0",
+  "com.lihaoyi"                 %% "upickle"                     % "0.4.4",
+  "com.github.julien-truffaut"  %% "monocle-core"                % "1.3.2",
+  "com.github.julien-truffaut"  %% "monocle-macro"               % "1.3.2",
+  "org.log4s"                   %% "log4s"                       % "1.3.3",
   "ch.qos.logback"              %  "logback-classic"             % "1.1.7",
-  "org.specs2"                  %% "specs2"                      % "3.7" % "test",
-  "org.typelevel"               %% "scalaz-specs2"               % "0.3.0"  % "test",
-  "org.scalacheck"              %% "scalacheck"                  % "1.13.0" % "test",
-  "org.scalaz"                  %% "scalaz-scalacheck-binding"   % "7.2.1"  % "test"
+  "org.typelevel"               %% "scalaz-specs2"               % "0.5.0"  % "test",
+  "org.scalacheck"              %% "scalacheck"                  % "1.13.5" % "test",
+  "org.scalaz"                  %% "scalaz-scalacheck-binding"   % "7.2.16"  % "test"
 )
+
+libraryDependencies += { scalaVersion(scalatestDependency).value }
+
+def scalatestDependency(scalaVersion: String) = scalaVersion match {
+  case sVersion if sVersion.startsWith("2.11") => "org.specs2" %% "specs2" % "3.7" % "test"
+  case sVersion if sVersion.startsWith("2.12") => "org.specs2" %% "specs2" % "3.8.9" % "test" exclude("org.specs2", "specs2-cats_2.12")
+}
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -46,27 +54,26 @@ scalacOptions ++= Seq(
   "-language:postfixOps",
   "-unchecked",
   "-Xfatal-warnings",
-  "-Xlint",
+//  "-Xlint",
   "-Yno-adapted-args",
   "-Ywarn-numeric-widen",
   "-Ywarn-value-discard",
   "-Xfuture",
-  "-Ywarn-unused-import"
+  "-Ywarn-unused-import",
+  "-Xmax-classfile-name", "128"
 )
 
 scalacOptions in (Compile, console) ~= (_ filterNot (
   List("-Ywarn-unused-import", "-Xfatal-warnings").contains(_)))
 
-wartremover.wartremoverSettings
-
-wartremover.wartremoverErrors in (Compile, compile) ++= Seq(
-  wartremover.Wart.Any,
-  wartremover.Wart.Any2StringAdd,
+wartremoverErrors ++= Seq(
+//  wartremover.Wart.Any,
+  wartremover.Wart.StringPlusAny,
   wartremover.Wart.EitherProjectionPartial,
-  wartremover.Wart.OptionPartial,
+//  wartremover.Wart.OptionPartial,
   wartremover.Wart.Product,
-  wartremover.Wart.Serializable,
-  wartremover.Wart.ListOps
+  wartremover.Wart.Serializable
+//  wartremover.Wart.TraversableOps
 )
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")

--- a/examples/src/main/scala/com/ibm/couchdb/examples/Basic.scala
+++ b/examples/src/main/scala/com/ibm/couchdb/examples/Basic.scala
@@ -20,6 +20,7 @@ import com.ibm.couchdb._
 import org.slf4j.LoggerFactory
 
 import scalaz._
+import com.ibm.couchdb.TaskOps
 import scalaz.concurrent.Task
 
 object Basic extends App {
@@ -56,7 +57,7 @@ object Basic extends App {
     } yield docs.getDocsData
 
     // Execute the actions and process the result
-    actions.unsafePerformSyncAttempt match {
+    actions.attemptRun match {
       // In case of an error (left side of Either), print it
       case -\/(e) => logger.error(e.getMessage, e)
       // In case of a success (right side of Either), print each object

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.0-RC1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.2")
 
-addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 

--- a/src/main/scala/com/ibm/couchdb/Model.scala
+++ b/src/main/scala/com/ibm/couchdb/Model.scala
@@ -111,6 +111,6 @@ case class CouchDesign(
     signatures: Map[String, String] = Map.empty[String, String])
 
 case class CouchException[D](content: D) extends Throwable {
-  override def toString: String = "CouchException: " + content
+  override def toString: String = "CouchException: " + content.toString
 }
 

--- a/src/main/scala/com/ibm/couchdb/api/Documents.scala
+++ b/src/main/scala/com/ibm/couchdb/api/Documents.scala
@@ -50,7 +50,7 @@ class Documents(client: Client, db: String, typeMapping: TypeMapping) {
       case None =>
         val cl = obj.getClass.getCanonicalName
         Res.Error(
-          "cannot_create", "No type mapping for " + cl + " available: " + typeMapping).toTask
+          "cannot_create", "No type mapping for " + cl + " available: " + typeMapping.toString).toTask
     }
   }
 
@@ -67,7 +67,7 @@ class Documents(client: Client, db: String, typeMapping: TypeMapping) {
   private def create[D: W, S](objs: Seq[(String, D)]): Task[Seq[Res.DocOk]] = {
     objs.find { x => !typeMapping.contains(x._2.getClass) } match {
       case Some(missing) =>
-        Res.Error("cannot_create", "No type mapping for " + missing).toTask
+        Res.Error("cannot_create", "No type mapping for " + missing.toString).toTask
       case None =>
         postBulk(
           objs.map { o => CouchDoc[D](


### PR DESCRIPTION
See also #71 

I did some preliminary work to make couchdb-scala work with Scala 2.12 (selecting and upgrading to dependencies that are 2.11 and 2.12-compatible). It compiles, but the tests don't pass yet. I get the following message when running `test` and then sbt locks up:

```
Exception in thread "http4s-blaze-client-2" java.lang.NoSuchMethodError: scalaz.syntax.Syntaxes$either$.ToEitherOps(Ljava/lang/Object;)Lscalaz/syntax/EitherOps;
	at org.http4s.util.TaskFunctions.$anonfun$futureToTask$2(Task.scala:26)
	at org.http4s.util.TaskFunctions.$anonfun$futureToTask$2$adapted(Task.scala:25)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```

I fear I may have accidentally included incompatible dependencies. Anyway, I would appreciate it if someone could take a look a this and possibly finish this - I don't have a lot of time for this ATM.